### PR TITLE
Add VagrantEngine for vm

### DIFF
--- a/pkg/engine/docker_test.go
+++ b/pkg/engine/docker_test.go
@@ -1,7 +1,6 @@
 package engine_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/mattjmcnaughton/tmplinux/pkg/engine"
@@ -61,24 +60,4 @@ func TestDockerEngineRmCommandSuccess(t *testing.T) {
 
 	assertKeywordIncludedInCommand(t, mockExecutor, "rm")
 	assertReporterNotCalled(t, mockReporter)
-}
-
-func assertKeywordIncludedInCommand(t *testing.T, mockExecutor executor.MockShellExecutor, keyword string) {
-	execCmd := mockExecutor.GetExecutedCommand()
-
-	if !strings.Contains(execCmd, keyword) {
-		t.Fatalf("%s should include the keyword %s", execCmd, keyword)
-	}
-}
-
-func assertReporterCalled(t *testing.T, mockReporter reporter.MockReporter) {
-	if !mockReporter.Reported() {
-		t.Fatalf("Reporter should have been called")
-	}
-}
-
-func assertReporterNotCalled(t *testing.T, mockReporter reporter.MockReporter) {
-	if mockReporter.Reported() {
-		t.Fatalf("Reporter should not have been called")
-	}
 }

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1,0 +1,45 @@
+package engine_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mattjmcnaughton/tmplinux/pkg/executor"
+	"github.com/mattjmcnaughton/tmplinux/pkg/reporter"
+)
+
+func assertKeywordIncludedInCommand(t *testing.T, mockExecutor executor.MockShellExecutor, keyword string) {
+	execCmds := mockExecutor.GetExecutedCommands()
+
+	anyMatches := false
+
+	for _, cmd := range execCmds {
+		if strings.Contains(cmd, keyword) {
+			anyMatches = true
+		}
+	}
+
+	if !anyMatches {
+		t.Fatalf("%v should include the keyword %s", execCmds, keyword)
+	}
+}
+
+func assertCommandIssuedInSubdirectoryOf(t *testing.T, mockExecutor executor.MockShellExecutor, parentDir string) {
+	execCmdDir := mockExecutor.GetExecutedCommandDir()
+
+	if !strings.HasPrefix(execCmdDir, parentDir) {
+		t.Fatalf("Command executed in %s, which is not a subdir of %s", execCmdDir, parentDir)
+	}
+}
+
+func assertReporterCalled(t *testing.T, mockReporter reporter.MockReporter) {
+	if !mockReporter.Reported() {
+		t.Fatalf("Reporter should have been called")
+	}
+}
+
+func assertReporterNotCalled(t *testing.T, mockReporter reporter.MockReporter) {
+	if mockReporter.Reported() {
+		t.Fatalf("Reporter should not have been called")
+	}
+}

--- a/pkg/engine/vagrant.go
+++ b/pkg/engine/vagrant.go
@@ -1,10 +1,13 @@
 package engine
 
 import (
-	"fmt"
-
 	"github.com/mattjmcnaughton/tmplinux/pkg/executor"
 	"github.com/mattjmcnaughton/tmplinux/pkg/reporter"
+)
+
+const (
+	vagrantBox     = "ubuntu/xenial64"
+	vagrantCmdName = "vagrant"
 )
 
 // VagrantEngine conforms to the `Engine` interface, and provides all the
@@ -23,27 +26,54 @@ func NewVagrantEngine() VagrantEngine {
 	}
 }
 
+// NewCustomVagrantEngine creates a new VagrantEngine, where the caller can
+// specify the injected executor and reporter.
+func NewCustomVagrantEngine(e executor.Executor, r reporter.Reporter) VagrantEngine {
+	return VagrantEngine{e, r}
+}
+
 // Start starts a tmp linux environment using Vagrant.
 func (v VagrantEngine) Start() {
-	fmt.Printf("start")
+	initCmdArgs := []string{"init", vagrantBox}
+	err := v.exec.RunInDirWithBoundOutput(v.getTmpDirPath(), vagrantCmdName, initCmdArgs...)
+	v.reporter.ReportIfError(err, "Failed to init vagrant vm")
+
+	upCmdArgs := []string{"up"}
+	err = v.exec.RunInDirWithBoundOutput(v.getTmpDirPath(), vagrantCmdName, upCmdArgs...)
+	v.reporter.ReportIfError(err, "Failed to start vagrant vm")
 }
 
 // SSH ssh's the user into the tmp linux environment.
 func (v VagrantEngine) SSH() {
-	fmt.Printf("ssh")
+	sshCmdArgs := []string{"ssh"}
+	err := v.exec.RunInDirWithBoundInputOutput(v.getTmpDirPath(), vagrantCmdName, sshCmdArgs...)
+	v.reporter.ReportIfError(err, "Failed to ssh into vagrant vm")
 }
 
 // Stop stops the users tmp linux environment.
 func (v VagrantEngine) Stop() {
-	fmt.Printf("stop")
+	stopCmdArgs := []string{"suspend"}
+	err := v.exec.RunInDirWithBoundOutput(v.getTmpDirPath(), vagrantCmdName, stopCmdArgs...)
+	v.reporter.ReportIfError(err, "Failed to stop vagrant vm")
 }
 
 // Rm stops the tmp linux environment.
 func (v VagrantEngine) Rm() {
-	fmt.Printf("rm")
+	rmCmdArgs := []string{"destroy", "-f"}
+	err := v.exec.RunInDirWithBoundOutput(v.getTmpDirPath(), vagrantCmdName, rmCmdArgs...)
+	v.reporter.ReportIfError(err, "Failed to remove vagrant vm")
+
+	err = v.exec.RunInDir(v.getTmpDirPath(), "rm", "Vagrantfile")
+	v.reporter.ReportIfError(err, "Failed to clean up Vagrantfile")
 }
 
 // Validate ensures all the necessary dependencies are in place.
 func (v VagrantEngine) Validate() {
-	fmt.Printf("validate")
+	validateCmdArgs := []string{"global-status"}
+	err := v.exec.RunInDir(v.getTmpDirPath(), vagrantCmdName, validateCmdArgs...)
+	v.reporter.ReportIfError(err, "Vagrant environment not properly setup")
+}
+
+func (v VagrantEngine) getTmpDirPath() string {
+	return "/tmp"
 }

--- a/pkg/engine/vagrant_test.go
+++ b/pkg/engine/vagrant_test.go
@@ -1,1 +1,86 @@
 package engine_test
+
+import (
+	"testing"
+
+	"github.com/mattjmcnaughton/tmplinux/pkg/engine"
+	"github.com/mattjmcnaughton/tmplinux/pkg/executor"
+	"github.com/mattjmcnaughton/tmplinux/pkg/reporter"
+)
+
+func TestVagrantEngineStartCommandSuccess(t *testing.T) {
+	mockExecutor := executor.CreateSuccessMockExecutor()
+	mockReporter := reporter.MockReporter{}
+
+	testVagrantEngine := engine.NewCustomVagrantEngine(&mockExecutor, &mockReporter)
+	testVagrantEngine.Start()
+
+	assertKeywordIncludedInCommand(t, mockExecutor, "init")
+	assertCommandIssuedInSubdirectoryOf(t, mockExecutor, "/tmp")
+	assertKeywordIncludedInCommand(t, mockExecutor, "up")
+	assertCommandIssuedInSubdirectoryOf(t, mockExecutor, "/tmp")
+
+	assertReporterNotCalled(t, mockReporter)
+}
+
+func TestVagrantEngineCommandFailed(t *testing.T) {
+	mockExecutor := executor.CreateFailureMockExecutor()
+	mockReporter := reporter.MockReporter{}
+
+	testVagrantEngine := engine.NewCustomVagrantEngine(&mockExecutor, &mockReporter)
+	testVagrantEngine.Start()
+
+	assertReporterCalled(t, mockReporter)
+}
+
+func TestVagrantEngineSSHCommandSuccess(t *testing.T) {
+	mockExecutor := executor.CreateSuccessMockExecutor()
+	mockReporter := reporter.MockReporter{}
+
+	testVagrantEngine := engine.NewCustomVagrantEngine(&mockExecutor, &mockReporter)
+	testVagrantEngine.SSH()
+
+	assertKeywordIncludedInCommand(t, mockExecutor, "ssh")
+	assertCommandIssuedInSubdirectoryOf(t, mockExecutor, "/tmp")
+	assertReporterNotCalled(t, mockReporter)
+}
+
+func TestVagrantEngineStopCommandSuccess(t *testing.T) {
+	mockExecutor := executor.CreateSuccessMockExecutor()
+	mockReporter := reporter.MockReporter{}
+
+	testVagrantEngine := engine.NewCustomVagrantEngine(&mockExecutor, &mockReporter)
+	testVagrantEngine.Stop()
+
+	assertKeywordIncludedInCommand(t, mockExecutor, "suspend")
+	assertCommandIssuedInSubdirectoryOf(t, mockExecutor, "/tmp")
+	assertReporterNotCalled(t, mockReporter)
+}
+
+func TestVagrantEngineRmCommandSuccess(t *testing.T) {
+	mockExecutor := executor.CreateSuccessMockExecutor()
+	mockReporter := reporter.MockReporter{}
+
+	testVagrantEngine := engine.NewCustomVagrantEngine(&mockExecutor, &mockReporter)
+	testVagrantEngine.Rm()
+
+	assertKeywordIncludedInCommand(t, mockExecutor, "destroy -f")
+	assertCommandIssuedInSubdirectoryOf(t, mockExecutor, "/tmp")
+	assertReporterNotCalled(t, mockReporter)
+
+	assertKeywordIncludedInCommand(t, mockExecutor, "rm")
+	assertCommandIssuedInSubdirectoryOf(t, mockExecutor, "/tmp")
+	assertReporterNotCalled(t, mockReporter)
+}
+
+func TestVagrantEngineValidateCommandSuccess(t *testing.T) {
+	mockExecutor := executor.CreateSuccessMockExecutor()
+	mockReporter := reporter.MockReporter{}
+
+	testVagrantEngine := engine.NewCustomVagrantEngine(&mockExecutor, &mockReporter)
+	testVagrantEngine.Validate()
+
+	assertKeywordIncludedInCommand(t, mockExecutor, "global-status")
+	assertCommandIssuedInSubdirectoryOf(t, mockExecutor, "/tmp")
+	assertReporterNotCalled(t, mockReporter)
+}

--- a/pkg/executor/exec.go
+++ b/pkg/executor/exec.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 )
@@ -11,6 +12,9 @@ type Executor interface {
 	Run(string, ...string) error
 	RunWithBoundOutput(string, ...string) error
 	RunWithBoundInputOutput(string, ...string) error
+	RunInDir(string, string, ...string) error
+	RunInDirWithBoundOutput(string, string, ...string) error
+	RunInDirWithBoundInputOutput(string, string, ...string) error
 }
 
 // ShellExecutor is a "production" executor which executes commands in the shell.
@@ -21,6 +25,15 @@ func (s *ShellExecutor) Run(name string, arg ...string) error {
 	cmd := exec.Command(name, arg...)
 
 	return cmd.Run()
+}
+
+// RunInDir executes the given command with the given dir as the working directory.
+func (s *ShellExecutor) RunInDir(dir string, name string, arg ...string) error {
+	cmd := func() error {
+		return s.Run(name, arg...)
+	}
+
+	return executeInDir(dir, cmd)
 }
 
 // RunWithBoundOutput executes the given command with just the output bound to
@@ -34,6 +47,16 @@ func (s *ShellExecutor) RunWithBoundOutput(name string, arg ...string) error {
 	return cmd.Run()
 }
 
+// RunInDirWithBoundOutput executes, in the given directory,
+// the given command with just the output bound to the current shell.
+func (s *ShellExecutor) RunInDirWithBoundOutput(dir string, name string, arg ...string) error {
+	cmd := func() error {
+		return s.RunWithBoundOutput(name, arg...)
+	}
+
+	return executeInDir(dir, cmd)
+}
+
 // RunWithBoundInputOutput executes the given command with the input and output
 // bound to the current shell.
 func (s *ShellExecutor) RunWithBoundInputOutput(name string, arg ...string) error {
@@ -44,4 +67,30 @@ func (s *ShellExecutor) RunWithBoundInputOutput(name string, arg ...string) erro
 	cmd.Stderr = os.Stderr
 
 	return cmd.Run()
+}
+
+// RunInDirWithBoundInputOutput executes, in the given directory,
+// the given command with the input and output bound to the current shell.
+func (s *ShellExecutor) RunInDirWithBoundInputOutput(dir string, name string, arg ...string) error {
+	cmd := func() error {
+		return s.RunWithBoundInputOutput(name, arg...)
+	}
+
+	return executeInDir(dir, cmd)
+}
+
+func executeInDir(dir string, cmd func() error) error {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("Unable to get current directory: %v", err)
+	}
+
+	err = os.Chdir(dir)
+	if err != nil {
+		return fmt.Errorf("Unable to chdir to %s: %v", dir, err)
+	}
+
+	defer os.Chdir(currentDir)
+
+	return cmd()
 }


### PR DESCRIPTION
Add the Vagrant Engine to drive vms. We can now create virtual linux
environments.

One choice I made here was to use the directory to control the Vagrant
environment, instead of the global id. I'm not sure if thats a good
decision - I can revisit it later if I want.