### PR TITLE
Use Bazel to build project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 tmplinux
 .idea
+bazel-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,15 @@ services:
   - docker
 
 install:
+  - sudo apt-get update && sudo apt-get install -y wget
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda install -y bazel
   - go get -u golang.org/x/tools/...
   - go get -u github.com/golang/lint/golint
   - go get -u github.com/golang/dep/cmd/dep
-  - make deps
+  - make build
 
 script:
   - make check

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@bazel_gazelle//:def.bzl", "gazelle")
+
+gazelle(
+    name = "gazelle",
+    prefix = "github.com/mattjmcnaughton/tmplinux",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/mattjmcnaughton/tmplinux",
+    visibility = ["//visibility:private"],
+    deps = ["//cmd:go_default_library"],
+)
+
+go_binary(
+    name = "tmplinux",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,14 @@
-build:
-	go build -o tmplinux main.go
+generate_build_files:
+	dep ensure && bazel run //:gazelle
+
+build: generate_build_files
+	bazel build tmplinux
 
 clean:
-	rm tmplinux
-
-tmpbuild: build clean
-
-deps:
-	dep ensure
+	bazel clean
 
 unit_test:
-	go test -v ./...
+	bazel test //pkg/...
 
 integration_test:
 	bash integration_test.sh
@@ -28,7 +26,7 @@ vet:
 
 static: lint fmt vet
 
-check: static test tmpbuild
+check: static test
 
 correct:
 	gofmt -w .

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,21 @@
+http_archive(
+    name = "io_bazel_rules_go",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.10.3/rules_go-0.10.3.tar.gz",
+    sha256 = "feba3278c13cde8d67e341a837f69a029f698d7a27ddbb2a202be7a10b22142a",
+)
+
+http_archive(
+    name = "bazel_gazelle",
+    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.10.1/bazel-gazelle-0.10.1.tar.gz",
+    sha256 = "d03625db67e9fb0905bbd206fa97e32ae9da894fe234a493e7517fd25faec914",
+)
+
+load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_repository", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains()
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+gazelle_dependencies()

--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "container.go",
+        "rm.go",
+        "root.go",
+        "ssh.go",
+        "start.go",
+        "stop.go",
+        "validate.go",
+        "version.go",
+        "vm.go",
+    ],
+    importpath = "github.com/mattjmcnaughton/tmplinux/cmd",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/virtualhost:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+    ],
+)

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -5,24 +5,29 @@
 
 set -e
 
+BAZEL_RUN="bazel run //:tmplinux"
+
 integration_test::setup() {
+  make clean
   make build
 }
 
 integration_test::run() {
-  ./tmplinux container validate
-  ./tmplinux container start
+  $BAZEL_RUN container validate
+  $BAZEL_RUN container start
 
-  ./tmplinux container ssh &
+  $BAZEL_RUN container ssh &
   local pid=$!
   kill -9 $pid
 
-  ./tmplinux container stop
-  ./tmplinux container rm
+  $BAZEL_RUN container stop
+  $BAZEL_RUN container rm
 }
 
 integration_test::teardown() {
+  local trap_code="$?"
   make clean
+  exit $trap_code
 }
 
 trap 'integration_test::teardown' EXIT

--- a/pkg/engine/BUILD.bazel
+++ b/pkg/engine/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "docker.go",
+        "engine.go",
+        "vagrant.go",
+    ],
+    importpath = "github.com/mattjmcnaughton/tmplinux/pkg/engine",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/executor:go_default_library",
+        "//pkg/reporter:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_xtest",
+    srcs = [
+        "docker_test.go",
+        "engine_test.go",
+        "vagrant_test.go",
+    ],
+    deps = [
+        ":go_default_library",
+        "//pkg/executor:go_default_library",
+        "//pkg/reporter:go_default_library",
+    ],
+)

--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "exec.go",
+        "mock_exec.go",
+    ],
+    importpath = "github.com/mattjmcnaughton/tmplinux/pkg/executor",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/reporter/BUILD.bazel
+++ b/pkg/reporter/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "mock_reporter.go",
+        "reporter.go",
+    ],
+    importpath = "github.com/mattjmcnaughton/tmplinux/pkg/reporter",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/virtualhost/BUILD.bazel
+++ b/pkg/virtualhost/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["virtualhost.go"],
+    importpath = "github.com/mattjmcnaughton/tmplinux/pkg/virtualhost",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/engine:go_default_library"],
+)


### PR DESCRIPTION
Experiment with using bazel to build the project. We still use dep to
manage dependencies, but bazel is responsible for creating build
artifacts, as well as running tests.

Rewrite the `Makefile` and `.travis.yml` to support.